### PR TITLE
Fix invalid call stack tree returned

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -25,11 +25,8 @@ return \PhpCsFixer\Config::create()
     ->setRules([
         '@PSR2' => true,
         '@Symfony' => true,
-        //'@Symfony:risky' => true,
         '@PHP70Migration' => true,
-        //'@PHP70Migration:risky' => true,
         '@PHP71Migration' => true,
-        //'@PHP71Migration:risky' => true,
         '@PHP73Migration' => true,
         'header_comment' => [
             'header' => $header,

--- a/src/EventWatcher.php
+++ b/src/EventWatcher.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+ * This file is part of the "Event Dispatcher" library.
+ *
+ * (c) Skoropadskyi Roman <zipo.ckorop@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zippovich2\EventDispatcher;
+
+class EventWatcher
+{
+    private $events = [];
+
+    private $subscribers = [];
+
+    private $level = 0;
+
+    public function startEvent(string $event)
+    {
+        if (\in_array($event, $this->events)) {
+            throw new \LogicException(\sprintf('Event "%s" is already started.', $event));
+        }
+
+        $this->events[] = $event;
+        ++$this->level;
+    }
+
+    public function stopEvent(string $event)
+    {
+        if (!\in_array($event, $this->events)) {
+            throw new \LogicException(\sprintf('There is no events with name "%s" to stop.', $event));
+        }
+
+        \array_pop($this->events);
+        --$this->level;
+    }
+
+    public function addEventSubscriber(string $subscriber)
+    {
+        if (0 === \count($this->events)) {
+            throw new \LogicException('There is no started events to add subscriber to it.');
+        }
+
+        $this->subscribers[] = [
+            'subscriber' => $subscriber,
+            'event' => $this->getActiveEvent(),
+            'level' => $this->level,
+            'parent' => $this->getParentEvent(),
+        ];
+    }
+
+    public function getEvents(): array
+    {
+        return $this->events;
+    }
+
+    public function getSubscribers(): array
+    {
+        return $this->subscribers;
+    }
+
+    public function reset(): void
+    {
+        $this->events = [];
+        $this->subscribers = [];
+    }
+
+    protected function getActiveEvent(): ?string
+    {
+        $activeEvent = \end($this->events);
+
+        return $activeEvent ?: null;
+    }
+
+    protected function getParentEvent(): ?string
+    {
+        return 1 === \count($this->events) ? null : $this->events[\count($this->events) - 2];
+    }
+}

--- a/tests/EventWatcherTest.php
+++ b/tests/EventWatcherTest.php
@@ -1,0 +1,126 @@
+<?php
+
+/*
+ * This file is part of the "Event Dispatcher" library.
+ *
+ * (c) Skoropadskyi Roman <zipo.ckorop@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zippovich2\EventDispatcher\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Zippovich2\EventDispatcher\EventWatcher;
+
+class EventWatcherTest extends TestCase
+{
+    public const EVENT_NAME_1 = 'event_name_1';
+    public const EVENT_NAME_2 = 'event_name_2';
+
+    /**
+     * @var EventWatcher
+     */
+    private $eventWatcher;
+
+    public function setUp(): void
+    {
+        $this->eventWatcher = new EventWatcher();
+    }
+
+    public function tearDown(): void
+    {
+        $this->eventWatcher = null;
+    }
+
+    public function testStartEvent(): void
+    {
+        $this->eventWatcher->startEvent(self::EVENT_NAME_1);
+        static::assertCount(1, $this->eventWatcher->getEvents());
+
+        $this->eventWatcher->startEvent(self::EVENT_NAME_2);
+        static::assertCount(2, $this->eventWatcher->getEvents());
+    }
+
+    public function testStartEventException(): void
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage(\sprintf('Event "%s" is already started.', self::EVENT_NAME_1));
+
+        $this->eventWatcher->startEvent(self::EVENT_NAME_1);
+        $this->eventWatcher->startEvent(self::EVENT_NAME_1);
+    }
+
+    public function testStopEvent(): void
+    {
+        $this->eventWatcher->startEvent(self::EVENT_NAME_1);
+        $this->eventWatcher->startEvent(self::EVENT_NAME_2);
+        static::assertCount(2, $this->eventWatcher->getEvents());
+
+        $this->eventWatcher->stopEvent(self::EVENT_NAME_2);
+        static::assertCount(1, $this->eventWatcher->getEvents());
+
+        $this->eventWatcher->stopEvent(self::EVENT_NAME_1);
+        static::assertCount(0, $this->eventWatcher->getEvents());
+    }
+
+    public function testStopEventException(): void
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage(\sprintf('There is no events with name "%s" to stop.', self::EVENT_NAME_1));
+
+        $this->eventWatcher->stopEvent(self::EVENT_NAME_1);
+    }
+
+    public function testAddEventSubscriber(): void
+    {
+        $this->eventWatcher->startEvent(self::EVENT_NAME_1);
+        $this->eventWatcher->addEventSubscriber('subscriber_1');
+
+        $this->eventWatcher->startEvent(self::EVENT_NAME_2);
+        $this->eventWatcher->addEventSubscriber('subscriber_2');
+        $this->eventWatcher->addEventSubscriber('subscriber_3');
+
+        $this->eventWatcher->stopEvent(self::EVENT_NAME_2);
+
+        $this->eventWatcher->addEventSubscriber('subscriber_4');
+
+        $this->eventWatcher->stopEvent(self::EVENT_NAME_1);
+
+        static::assertEquals([
+            [
+                'subscriber' => 'subscriber_1',
+                'event' => self::EVENT_NAME_1,
+                'level' => 1,
+                'parent' => null,
+            ],
+            [
+                'subscriber' => 'subscriber_2',
+                'event' => self::EVENT_NAME_2,
+                'level' => 2,
+                'parent' => self::EVENT_NAME_1,
+            ],
+            [
+                'subscriber' => 'subscriber_3',
+                'event' => self::EVENT_NAME_2,
+                'level' => 2,
+                'parent' => self::EVENT_NAME_1,
+            ],
+            [
+                'subscriber' => 'subscriber_4',
+                'event' => self::EVENT_NAME_1,
+                'level' => 1,
+                'parent' => null,
+            ],
+        ], $this->eventWatcher->getSubscribers());
+    }
+
+    public function testAddEventSubscriberException(): void
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('There is no started events to add subscriber to it.');
+
+        $this->eventWatcher->addEventSubscriber('subscriber_1');
+    }
+}

--- a/tests/Fixtures/AbstractSubscriber.php
+++ b/tests/Fixtures/AbstractSubscriber.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the "Event Dispatcher" library.
+ *
+ * (c) Skoropadskyi Roman <zipo.ckorop@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zippovich2\EventDispatcher\Tests\Fixtures;
+
+use Zippovich2\EventDispatcher\EventDispatcherInterface;
+
+abstract class AbstractSubscriber
+{
+    /**
+     * @var EventDispatcherInterface
+     */
+    protected $dispatcher;
+
+    public function __construct(EventDispatcherInterface $dispatcher)
+    {
+        $this->dispatcher = $dispatcher;
+    }
+
+    abstract public function handle();
+}

--- a/tests/Fixtures/Bug1/SubscriberA.php
+++ b/tests/Fixtures/Bug1/SubscriberA.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the "Event Dispatcher" library.
+ *
+ * (c) Skoropadskyi Roman <zipo.ckorop@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zippovich2\EventDispatcher\Tests\Fixtures\Bug1;
+
+use Zippovich2\EventDispatcher\Tests\Fixtures\AbstractSubscriber;
+
+class SubscriberA extends AbstractSubscriber
+{
+    public function handle()
+    {
+        $this->dispatcher->dispatch('B');
+        $this->dispatcher->dispatch('C');
+    }
+}

--- a/tests/Fixtures/Bug1/SubscriberB.php
+++ b/tests/Fixtures/Bug1/SubscriberB.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the "Event Dispatcher" library.
+ *
+ * (c) Skoropadskyi Roman <zipo.ckorop@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zippovich2\EventDispatcher\Tests\Fixtures\Bug1;
+
+use Zippovich2\EventDispatcher\Tests\Fixtures\AbstractSubscriber;
+
+class SubscriberB extends AbstractSubscriber
+{
+    public function handle()
+    {
+        $this->dispatcher->dispatch('D');
+    }
+}

--- a/tests/Fixtures/Bug1/SubscriberC.php
+++ b/tests/Fixtures/Bug1/SubscriberC.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the "Event Dispatcher" library.
+ *
+ * (c) Skoropadskyi Roman <zipo.ckorop@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zippovich2\EventDispatcher\Tests\Fixtures\Bug1;
+
+use Zippovich2\EventDispatcher\Tests\Fixtures\AbstractSubscriber;
+
+class SubscriberC extends AbstractSubscriber
+{
+    public function handle()
+    {
+    }
+}

--- a/tests/Fixtures/Bug1/SubscriberD.php
+++ b/tests/Fixtures/Bug1/SubscriberD.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the "Event Dispatcher" library.
+ *
+ * (c) Skoropadskyi Roman <zipo.ckorop@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zippovich2\EventDispatcher\Tests\Fixtures\Bug1;
+
+use Zippovich2\EventDispatcher\Tests\Fixtures\AbstractSubscriber;
+
+class SubscriberD extends AbstractSubscriber
+{
+    public function handle()
+    {
+    }
+}

--- a/tests/Fixtures/ComplexNestedEvents/SubscriberA.php
+++ b/tests/Fixtures/ComplexNestedEvents/SubscriberA.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the "Event Dispatcher" library.
+ *
+ * (c) Skoropadskyi Roman <zipo.ckorop@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zippovich2\EventDispatcher\Tests\Fixtures\ComplexNestedEvents;
+
+use Zippovich2\EventDispatcher\Tests\Fixtures\AbstractSubscriber;
+
+class SubscriberA extends AbstractSubscriber
+{
+    public function handle()
+    {
+        $this->dispatcher->dispatch('B');
+        $this->dispatcher->dispatch('D');
+    }
+
+    public function handle2()
+    {
+        $this->dispatcher->dispatch('E');
+        $this->dispatcher->dispatch('F');
+        $this->dispatcher->dispatch('G');
+        $this->dispatcher->dispatch('H');
+    }
+}

--- a/tests/Fixtures/ComplexNestedEvents/SubscriberB.php
+++ b/tests/Fixtures/ComplexNestedEvents/SubscriberB.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the "Event Dispatcher" library.
+ *
+ * (c) Skoropadskyi Roman <zipo.ckorop@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zippovich2\EventDispatcher\Tests\Fixtures\ComplexNestedEvents;
+
+use Zippovich2\EventDispatcher\Tests\Fixtures\AbstractSubscriber;
+
+class SubscriberB extends AbstractSubscriber
+{
+    public function handle()
+    {
+        $this->dispatcher->dispatch('C');
+    }
+}

--- a/tests/Fixtures/ComplexNestedEvents/SubscriberC.php
+++ b/tests/Fixtures/ComplexNestedEvents/SubscriberC.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the "Event Dispatcher" library.
+ *
+ * (c) Skoropadskyi Roman <zipo.ckorop@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zippovich2\EventDispatcher\Tests\Fixtures\ComplexNestedEvents;
+
+use Zippovich2\EventDispatcher\Tests\Fixtures\AbstractSubscriber;
+
+class SubscriberC extends AbstractSubscriber
+{
+    public function handle()
+    {
+    }
+}

--- a/tests/Fixtures/ComplexNestedEvents/SubscriberD.php
+++ b/tests/Fixtures/ComplexNestedEvents/SubscriberD.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the "Event Dispatcher" library.
+ *
+ * (c) Skoropadskyi Roman <zipo.ckorop@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zippovich2\EventDispatcher\Tests\Fixtures\ComplexNestedEvents;
+
+use Zippovich2\EventDispatcher\Tests\Fixtures\AbstractSubscriber;
+
+class SubscriberD extends AbstractSubscriber
+{
+    public function handle()
+    {
+    }
+}

--- a/tests/Fixtures/ComplexNestedEvents/SubscriberE.php
+++ b/tests/Fixtures/ComplexNestedEvents/SubscriberE.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the "Event Dispatcher" library.
+ *
+ * (c) Skoropadskyi Roman <zipo.ckorop@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zippovich2\EventDispatcher\Tests\Fixtures\ComplexNestedEvents;
+
+use Zippovich2\EventDispatcher\Tests\Fixtures\AbstractSubscriber;
+
+class SubscriberE extends AbstractSubscriber
+{
+    public function handle()
+    {
+        $this->dispatcher->dispatch('B');
+    }
+}

--- a/tests/Fixtures/ComplexNestedEvents/SubscriberF.php
+++ b/tests/Fixtures/ComplexNestedEvents/SubscriberF.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the "Event Dispatcher" library.
+ *
+ * (c) Skoropadskyi Roman <zipo.ckorop@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zippovich2\EventDispatcher\Tests\Fixtures\ComplexNestedEvents;
+
+use Zippovich2\EventDispatcher\Tests\Fixtures\AbstractSubscriber;
+
+class SubscriberF extends AbstractSubscriber
+{
+    public function handle()
+    {
+    }
+}

--- a/tests/Fixtures/ComplexNestedEvents/SubscriberG.php
+++ b/tests/Fixtures/ComplexNestedEvents/SubscriberG.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the "Event Dispatcher" library.
+ *
+ * (c) Skoropadskyi Roman <zipo.ckorop@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zippovich2\EventDispatcher\Tests\Fixtures\ComplexNestedEvents;
+
+use Zippovich2\EventDispatcher\Tests\Fixtures\AbstractSubscriber;
+
+class SubscriberG extends AbstractSubscriber
+{
+    public function handle()
+    {
+    }
+}

--- a/tests/Fixtures/ComplexNestedEvents/SubscriberH.php
+++ b/tests/Fixtures/ComplexNestedEvents/SubscriberH.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the "Event Dispatcher" library.
+ *
+ * (c) Skoropadskyi Roman <zipo.ckorop@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zippovich2\EventDispatcher\Tests\Fixtures\ComplexNestedEvents;
+
+use Zippovich2\EventDispatcher\Tests\Fixtures\AbstractSubscriber;
+
+class SubscriberH extends AbstractSubscriber
+{
+    public function handle()
+    {
+        $this->dispatcher->dispatch('E');
+    }
+}

--- a/tests/Fixtures/PekariumCase/BalanceUpdateSubscriber.php
+++ b/tests/Fixtures/PekariumCase/BalanceUpdateSubscriber.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Zippovich2\EventDispatcher\Tests\Fixtures;
+namespace Zippovich2\EventDispatcher\Tests\Fixtures\PekariumCase;
 
 use Zippovich2\EventDispatcher\EventDispatcher;
 

--- a/tests/Fixtures/PekariumCase/TransactionSubscriber.php
+++ b/tests/Fixtures/PekariumCase/TransactionSubscriber.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Zippovich2\EventDispatcher\Tests\Fixtures;
+namespace Zippovich2\EventDispatcher\Tests\Fixtures\PekariumCase;
 
 use Zippovich2\EventDispatcher\TraceableEventDispatcherInterface;
 

--- a/tests/TraceableEventDispatcherTest.php
+++ b/tests/TraceableEventDispatcherTest.php
@@ -15,10 +15,23 @@ namespace Zippovich2\EventDispatcher\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Zippovich2\EventDispatcher\EventDispatcher;
-use Zippovich2\EventDispatcher\Tests\Fixtures\BalanceUpdateSubscriber;
+use Zippovich2\EventDispatcher\EventWatcher;
+use Zippovich2\EventDispatcher\Tests\Fixtures\Bug1\SubscriberA;
+use Zippovich2\EventDispatcher\Tests\Fixtures\Bug1\SubscriberB;
+use Zippovich2\EventDispatcher\Tests\Fixtures\Bug1\SubscriberC;
+use Zippovich2\EventDispatcher\Tests\Fixtures\Bug1\SubscriberD;
+use Zippovich2\EventDispatcher\Tests\Fixtures\ComplexNestedEvents\SubscriberA as ComplexCaseSubscriberA;
+use Zippovich2\EventDispatcher\Tests\Fixtures\ComplexNestedEvents\SubscriberB as ComplexCaseSubscriberB;
+use Zippovich2\EventDispatcher\Tests\Fixtures\ComplexNestedEvents\SubscriberC as ComplexCaseSubscriberC;
+use Zippovich2\EventDispatcher\Tests\Fixtures\ComplexNestedEvents\SubscriberD as ComplexCaseSubscriberD;
+use Zippovich2\EventDispatcher\Tests\Fixtures\ComplexNestedEvents\SubscriberE as ComplexCaseSubscriberE;
+use Zippovich2\EventDispatcher\Tests\Fixtures\ComplexNestedEvents\SubscriberF as ComplexCaseSubscriberF;
+use Zippovich2\EventDispatcher\Tests\Fixtures\ComplexNestedEvents\SubscriberG as ComplexCaseSubscriberG;
+use Zippovich2\EventDispatcher\Tests\Fixtures\ComplexNestedEvents\SubscriberH as ComplexCaseSubscriberH;
+use Zippovich2\EventDispatcher\Tests\Fixtures\PekariumCase\BalanceUpdateSubscriber;
+use Zippovich2\EventDispatcher\Tests\Fixtures\PekariumCase\TransactionSubscriber;
 use Zippovich2\EventDispatcher\Tests\Fixtures\Subscriber;
 use Zippovich2\EventDispatcher\Tests\Fixtures\SubscriberWithTraceableEventDispatcher;
-use Zippovich2\EventDispatcher\Tests\Fixtures\TransactionSubscriber;
 use Zippovich2\EventDispatcher\TraceableEventDispatcher;
 
 class TraceableEventDispatcherTest extends TestCase
@@ -30,7 +43,7 @@ class TraceableEventDispatcherTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->dispatcher = new TraceableEventDispatcher();
+        $this->dispatcher = new TraceableEventDispatcher(new EventWatcher());
     }
 
     protected function tearDown(): void
@@ -96,7 +109,7 @@ class TraceableEventDispatcherTest extends TestCase
         $this->dispatcher->subscribe('event1', [$subscriber, 'callback2']);
         $this->dispatcher->subscribe('event2', [$subscriber, 'callback2']);
 
-        $this->dispatcher->dispatch('event1');
+        $callStackTree = $this->dispatcher->dispatch('event1');
 
         $expected = [
             [
@@ -112,7 +125,7 @@ class TraceableEventDispatcherTest extends TestCase
             ],
         ];
 
-        static::assertEquals($expected, $this->dispatcher->getCallStackTree());
+        static::assertEquals($expected, $callStackTree);
         static::assertEquals(1, $subscriber->callback1InvokedTimes);
         static::assertEquals(2, $subscriber->callback2InvokedTimes);
     }
@@ -181,7 +194,7 @@ class TraceableEventDispatcherTest extends TestCase
         $this->dispatcher->subscribe('BonusTransactionCompletedEvent', [$transactionSubscriber, 'creditBalance']);
         $this->dispatcher->subscribe('BalanceUpdatedEvent', [$balanceUpdateSubscriber, 'notifyUser']);
 
-        $this->dispatcher->dispatch('TransactionCompletedEvent');
+        $callStackTree = $this->dispatcher->dispatch('TransactionCompletedEvent');
 
         $expected = [
             [
@@ -210,12 +223,152 @@ class TraceableEventDispatcherTest extends TestCase
             ],
         ];
 
-        static::assertEquals($expected, $this->dispatcher->getCallStackTree());
+        static::assertEquals($expected, $callStackTree);
         static::assertEquals(2, $transactionSubscriber->creditBalanceInvokedTimes);
         static::assertEquals(1, $transactionSubscriber->calculateBonusesInvokedTimes);
         static::assertEquals(1, $transactionSubscriber->sendEmailInvokedTimes);
         static::assertEquals(2, $balanceUpdateSubscriber->notifyUserInvokedTimes);
 
         static::assertTrue(true);
+    }
+
+    public function testBug1()
+    {
+        $subscriberA = new SubscriberA($this->dispatcher);
+        $subscriberB = new SubscriberB($this->dispatcher);
+        $subscriberC = new SubscriberC($this->dispatcher);
+        $subscriberD = new SubscriberD($this->dispatcher);
+
+        $this->dispatcher->subscribe('A', [$subscriberA, 'handle']);
+        $this->dispatcher->subscribe('B', [$subscriberB, 'handle']);
+        $this->dispatcher->subscribe('C', [$subscriberC, 'handle']);
+        $this->dispatcher->subscribe('D', [$subscriberD, 'handle']);
+
+        $callStackTree = $this->dispatcher->dispatch('A');
+
+        $expected = [
+            [
+                'subscriber' => \sprintf('%s::%s', \get_class($subscriberA), 'handle'),
+                'children' => [
+                    [
+                        'subscriber' => \sprintf('%s::%s', \get_class($subscriberB), 'handle'),
+                        'children' => [
+                            [
+                                'subscriber' => \sprintf('%s::%s', \get_class($subscriberD), 'handle'),
+                            ],
+                        ],
+                    ],
+                    [
+                        'subscriber' => \sprintf('%s::%s', \get_class($subscriberC), 'handle'),
+                    ],
+                ],
+            ],
+        ];
+
+        static::assertEquals($expected, $callStackTree);
+    }
+
+    /**
+     * Testing nested tree:
+     *  -A
+     *  --B
+     *  ---C
+     *  --D
+     *  -A
+     *  --E
+     *  ---B
+     *  ----C
+     *  --F
+     *  --G
+     *  --H
+     *  ---E
+     *  ----B
+     *  -----C.
+     */
+    public function testGetCallStackTreeWithComplexNestedEvents(): void
+    {
+        $subscriberA = new ComplexCaseSubscriberA($this->dispatcher);
+        $subscriberB = new ComplexCaseSubscriberB($this->dispatcher);
+        $subscriberC = new ComplexCaseSubscriberC($this->dispatcher);
+        $subscriberD = new ComplexCaseSubscriberD($this->dispatcher);
+        $subscriberE = new ComplexCaseSubscriberE($this->dispatcher);
+        $subscriberF = new ComplexCaseSubscriberF($this->dispatcher);
+        $subscriberG = new ComplexCaseSubscriberG($this->dispatcher);
+        $subscriberH = new ComplexCaseSubscriberH($this->dispatcher);
+
+        $this->dispatcher->subscribe('A', [$subscriberA, 'handle']);
+        $this->dispatcher->subscribe('A', [$subscriberA, 'handle2']);
+        $this->dispatcher->subscribe('B', [$subscriberB, 'handle']);
+        $this->dispatcher->subscribe('C', [$subscriberC, 'handle']);
+        $this->dispatcher->subscribe('D', [$subscriberD, 'handle']);
+        $this->dispatcher->subscribe('E', [$subscriberE, 'handle']);
+        $this->dispatcher->subscribe('F', [$subscriberF, 'handle']);
+        $this->dispatcher->subscribe('G', [$subscriberG, 'handle']);
+        $this->dispatcher->subscribe('H', [$subscriberH, 'handle']);
+
+        $callStackTree = $this->dispatcher->dispatch('A');
+
+        $expected = [
+            [
+                'subscriber' => \sprintf('%s::%s', \get_class($subscriberA), 'handle'),
+                'children' => [
+                    [
+                        'subscriber' => \sprintf('%s::%s', \get_class($subscriberB), 'handle'),
+                        'children' => [
+                            [
+                                'subscriber' => \sprintf('%s::%s', \get_class($subscriberC), 'handle'),
+                            ],
+                        ],
+                    ],
+                    [
+                        'subscriber' => \sprintf('%s::%s', \get_class($subscriberD), 'handle'),
+                    ],
+                ],
+            ],
+            [
+                'subscriber' => \sprintf('%s::%s', \get_class($subscriberA), 'handle2'),
+                'children' => [
+                    [
+                        'subscriber' => \sprintf('%s::%s', \get_class($subscriberE), 'handle'),
+                        'children' => [
+                            [
+                                'subscriber' => \sprintf('%s::%s', \get_class($subscriberB), 'handle'),
+                                'children' => [
+                                    [
+                                        'subscriber' => \sprintf('%s::%s', \get_class($subscriberC), 'handle'),
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                    [
+                        'subscriber' => \sprintf('%s::%s', \get_class($subscriberF), 'handle'),
+                    ],
+                    [
+                        'subscriber' => \sprintf('%s::%s', \get_class($subscriberG), 'handle'),
+                    ],
+                    [
+                        'subscriber' => \sprintf('%s::%s', \get_class($subscriberH), 'handle'),
+                        'children' => [
+                            [
+                                'subscriber' => \sprintf('%s::%s', \get_class($subscriberE), 'handle'),
+                                'children' => [
+                                    [
+                                        'subscriber' => \sprintf('%s::%s', \get_class($subscriberB), 'handle'),
+                                        'children' => [
+                                            [
+                                                'subscriber' => \sprintf('%s::%s', \get_class($subscriberC), 'handle'),
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        static::assertEquals($expected, $callStackTree);
     }
 }


### PR DESCRIPTION
Fixes #1 when invalid call stack tree returned.

**Changes:**

1. Added event watcher to split events subscribers on sections by events.
2. Added test to check #1. 
2. Added one more test.